### PR TITLE
Better home install script

### DIFF
--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -1,15 +1,60 @@
-#/bin/bash
+#!/bin/bash
+
+# Download and install the latest Papirus Icon theme
+
+#set -x
+set -e
+
+DL_URL="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip"
+TARGET_DIR=$HOME/.icons
+HASH_FILE=$TARGET_DIR/.papirus-icons.etag
+
+get_remote_hash() {
+    curl -i -s -I -L $DL_URL | grep -i '^ETag: '
+}
+
+get_local_hash() {
+    touch $HASH_FILE
+    cat $HASH_FILE
+}
+
+extract() {
+    if [ -x /usr/bin/7z ]; then
+        /usr/bin/7z x "$1" -o"$2"
+    else
+        /usr/bin/unzip "$1" -d "$2"
+    fi
+}
+
 echo "Papirus icon theme for GTK"
-sleep 5
-echo "Delete old Papirus icon theme ..."
-rm -rf ~/.icons/{Papirus-GTK,Papirus-Dark-GTK}
+
+mkdir -p $TARGET_DIR
+
+echo "Comparing versions ..."
+REMOTE_HASH=$(get_remote_hash)
+LOCAL_HASH=$(get_local_hash)
+
+if [ "$REMOTE_HASH" == "$LOCAL_HASH" ]
+then
+    echo "Already using the latest version"
+    exit 0
+fi
+
 echo "Download new version from GitHub ..."
-wget -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip -O /tmp/papirus-icon-theme-gtk.zip
+TEMP_DIR=$(mktemp -d)
+curl -L $DL_URL -o $TEMP_DIR/master.zip
+
 echo "Unpack archive ..."
-7z x /tmp/papirus-icon-theme-gtk.zip -o/tmp/
+extract $TEMP_DIR/master.zip $TEMP_DIR
+
+echo "Delete old Papirus icon theme ..."
+rm -rf $TARGET/{Papirus-GTK,Papirus-Dark-GTK}
+
 echo "Installing ..."
-mkdir ~/.icons
-cp -R /tmp/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} ~/.icons/
+mv $TEMP_DIR/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} $TARGET
+
+echo -n "$REMOTE_HASH" > $HASH_FILE
+
 echo "Delete cache ..."
-rm -rf /tmp/papiru*
+rm -rf $TEMP_DIR
 echo "Done!"


### PR DESCRIPTION
Improvements:

* It deletes the current directories just before putting the new ones. It also
  uses mv to move the icon dirs instead of copying them. This is much faster
  if your home and temp directories are in the same partition
* Checks if the version on GitHub is different than the currently installed
  one before downloading and replacing the files
* Falls back to unzip if it cannot find 7z
* Uses a temp directory, so most of the things should work fine even if you're
  running 2 copies of the script simultaneously (e.g. in crontab)

Other notes:

* Requires mktemp. I think it's installed by default but I'm not 100% sure.
* Uses curl instead of wget, because it's easier to issue HEAD requests
* GitHub returns an etag (which we are using for the version check), but
  doesn't seem to pay attention to the "If-None-Match" header, so I make 2
  curl requests. It would be good if we can fix that.
* It stores the current etag in ~/.icons/.papirus-icons.etag. If you wish to
  force it to download and install the icons, you can just remove this file
  and run the script.