### PR TITLE
Fix ClipIt tray icon

### DIFF
--- a/Papirus-GTK/16x16/apps/clipit-trayicon.svg
+++ b/Papirus-GTK/16x16/apps/clipit-trayicon.svg
@@ -1,1 +1,0 @@
-diodon.svg

--- a/Papirus-GTK/22x22/apps/clipit-trayicon.svg
+++ b/Papirus-GTK/22x22/apps/clipit-trayicon.svg
@@ -1,1 +1,0 @@
-diodon.svg

--- a/Papirus-GTK/24x24/apps/clipit-trayicon.svg
+++ b/Papirus-GTK/24x24/apps/clipit-trayicon.svg
@@ -1,1 +1,0 @@
-diodon.svg

--- a/Papirus-GTK/32x32/apps/clipit-trayicon.svg
+++ b/Papirus-GTK/32x32/apps/clipit-trayicon.svg
@@ -1,1 +1,0 @@
-diodon.svg

--- a/Papirus-GTK/48x48/apps/clipit-trayicon.svg
+++ b/Papirus-GTK/48x48/apps/clipit-trayicon.svg
@@ -1,1 +1,0 @@
-diodon.svg


### PR DESCRIPTION
![screenshot-clipit-fix](https://cloud.githubusercontent.com/assets/819186/20289227/53aaa9b6-aae1-11e6-8b69-713a2f8f438e.png)

ClipIt not support separate icons for apps and panel. The best solution is to remove the icons from apps, like in Faenza:

> /usr/share/icons/Faenza $ ffind -ri 'clipit'
> ./status/22/clipit-trayicon.png
> ./status/24/clipit-trayicon.png
> /usr/share/icons/Faenza $

