### PR TITLE
Installation script improvements

### DIFF
--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
+
 echo "Papirus icon theme for GTK"
-sleep 5
+! which 7za > /dev/null 2>&1 && { echo "Please install p7zip"; exit 1; }
 echo "Delete old Papirus icon theme ..."
 rm -rf ~/.icons/{Papirus-GTK,Papirus-Dark-GTK}
 echo "Download new version from GitHub ..."
-wget -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip -O /tmp/papirus-icon-theme-gtk.zip
+wget -q --show-progress -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip \
+    -O /tmp/papirus-icon-theme-gtk.zip
 echo "Unpack archive ..."
-7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/
+7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/ > /dev/null
 echo "Installing ..."
-mkdir ~/.icons
+mkdir -p ~/.icons
 cp -R /tmp/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} ~/.icons/
 echo "Delete cache ..."
 rm -rf /tmp/papiru*

--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 echo "Papirus icon theme for GTK"
-sleep 5
+! which 7za > /dev/null 2>&1 && { echo "Please install p7zip"; exit 1; }
 echo "Delete old Papirus icon theme ..."
 sudo rm -rf /usr/share/icons/{Papirus-GTK,Papirus-Dark-GTK}
 echo "Download new version from GitHub ..."
-wget -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip -O /tmp/papirus-icon-theme-gtk.zip
+wget -q --show-progress -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip \
+    -O /tmp/papirus-icon-theme-gtk.zip
 echo "Unpack archive ..."
-7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/
+7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/ > /dev/null
 echo "Installing ..."
 sudo cp -R /tmp/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} /usr/share/icons/
 sudo chmod -R 755 /usr/share/icons/{Papirus-GTK,Papirus-Dark-GTK}


### PR DESCRIPTION
Make sure the needed commands, 7za, is available before
starting installation.

Make wget and 7za output less verbose.

Make mkdir not give an error if the directory already exist.

No need to sleep?