### PR TITLE
New installer for Papirus projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,25 @@ Papirus - it's SVG icon theme for Linux, based on [Paper](https://github.com/snw
 # Install / Update
 ## ROOT directory
 ```
-wget -O - https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-root.sh | bash
+curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-root.sh | sh
 ```
 ## HOME directory
 ```
-wget -O - https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | bash
+curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh
 ```
 **Depends:**
-- wget
-- p7zip-full
+- curl
+- tar
 - libqt4-svg (optional, need for right work on Qt4-apps)
 
 For easy way update you can add bash alias `update-papirus`:
 ```
-echo 'alias update-papirus="wget -O - https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | bash"' >> ~/.bashrc
+echo 'alias update-papirus="curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh"' >> ~/.bashrc
 ```
 
 # Remove
 ```
-wget -O - https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/remove-papirus.sh | bash
+curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/remove-papirus.sh | sh
 ```
 
 # Hardcoded tray icons

--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -1,15 +1,40 @@
-#!/usr/bin/env bash
-echo "Papirus icon theme for GTK"
-! which 7za > /dev/null 2>&1 && { echo "Please install p7zip-full"; exit 1; }
-echo "Download new version from GitHub ..."
-wget -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip -O /tmp/papirus-icon-theme-gtk.zip
-echo "Unpack archive ..."
-7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/ > /dev/null
-echo "Delete old Papirus icon theme ..."
-rm -rf ~/.icons/{Papirus-GTK,Papirus-Dark-GTK}
-echo "Installing ..."
+#!/bin/sh
+
+set -e
+
+cat <<- 'EOF'
+
+
+
+      ppppp                         ii
+      pp   pp     aaaaa   ppppp          rr  rrr   uu   uu     sssss
+      ppppp     aa   aa   pp   pp   ii   rrrr      uu   uu   ssss
+      pp        aa   aa   pp   pp   ii   rr        uu   uu      ssss
+      pp          aaaaa   ppppp     ii   rr          uuuuu   sssss
+                          pp
+                          pp
+
+
+  Papirus icon theme for GTK
+  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+
+
+EOF
+
+temp_dir=$(mktemp -d)
+
+echo "=> Getting the latest version from GitHub ..."
+curl --progress-bar -Lfo /tmp/papirus-icon-theme-gtk.tar.gz \
+  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.tar.gz
+echo "=> Unpacking archive ..."
+tar -xzf /tmp/papirus-icon-theme-gtk.tar.gz -C "$temp_dir"
+echo "=> Deleting old Papirus icon theme ..."
+rm -rf ~/.icons/Papirus-GTK ~/.icons/Papirus-Dark-GTK
+echo "=> Installing ..."
 mkdir -p ~/.icons
-cp -R /tmp/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} ~/.icons/
-echo "Delete cache ..."
-rm -rf /tmp/papiru*
-echo "Done!"
+cp --no-preserve=mode,ownership -r \
+  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-GTK" \
+  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-Dark-GTK" ~/.icons/
+echo "=> Clearing cache ..."
+rm -rf /tmp/papirus-icon-theme-gtk.tar.gz "$temp_dir"
+echo "=> Done!"

--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -1,15 +1,39 @@
-#!/usr/bin/env bash
-echo "Papirus icon theme for GTK"
-! which 7za > /dev/null 2>&1 && { echo "Please install p7zip-full"; exit 1; }
-echo "Download new version from GitHub ..."
-wget -c https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.zip -O /tmp/papirus-icon-theme-gtk.zip
-echo "Unpack archive ..."
-7za x /tmp/papirus-icon-theme-gtk.zip -o/tmp/ > /dev/null
-echo "Delete old Papirus icon theme ..."
-sudo rm -rf /usr/share/icons/{Papirus-GTK,Papirus-Dark-GTK}
-echo "Installing ..."
-sudo cp -R /tmp/papirus-icon-theme-gtk-master/{Papirus-GTK,Papirus-Dark-GTK} /usr/share/icons/
-sudo chmod -R 755 /usr/share/icons/{Papirus-GTK,Papirus-Dark-GTK}
-echo "Delete cache ..."
-rm -rf /tmp/papiru*
-echo "Done!"
+#!/bin/sh
+
+set -e
+
+cat <<- 'EOF'
+
+
+
+      ppppp                         ii
+      pp   pp     aaaaa   ppppp          rr  rrr   uu   uu     sssss
+      ppppp     aa   aa   pp   pp   ii   rrrr      uu   uu   ssss
+      pp        aa   aa   pp   pp   ii   rr        uu   uu      ssss
+      pp          aaaaa   ppppp     ii   rr          uuuuu   sssss
+                          pp
+                          pp
+
+
+  Papirus icon theme for GTK
+  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+
+
+EOF
+
+temp_dir=$(mktemp -d)
+
+echo "=> Getting the latest version from GitHub ..."
+curl --progress-bar -Lfo /tmp/papirus-icon-theme-gtk.tar.gz \
+  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.tar.gz
+echo "=> Unpacking archive ..."
+tar -xzf /tmp/papirus-icon-theme-gtk.tar.gz -C "$temp_dir"
+echo "=> Deleting old Papirus icon theme ..."
+sudo rm -rf /usr/share/icons/Papirus-GTK /usr/share/icons/Papirus-Dark-GTK
+echo "=> Installing ..."
+sudo cp --no-preserve=mode,ownership -r \
+  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-GTK" \
+  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-Dark-GTK" /usr/share/icons/
+echo "=> Clearing cache ..."
+rm -rf /tmp/papirus-icon-theme-gtk.tar.gz "$temp_dir"
+echo "=> Done!"

--- a/remove-papirus.sh
+++ b/remove-papirus.sh
@@ -1,5 +1,27 @@
-#!/usr/bin/env bash
-echo "Remove Papirus icon theme for GTK"
-sudo rm -rf /usr/share/icons/{Papirus-GTK,Papirus-Dark-GTK}
-rm -rf ~/.icons/{Papirus-GTK,Papirus-Dark-GTK}
-echo "Done!"
+#!/bin/sh
+
+set -e
+
+cat <<- 'EOF'
+
+
+
+      ppppp                         ii
+      pp   pp     aaaaa   ppppp          rr  rrr   uu   uu     sssss
+      ppppp     aa   aa   pp   pp   ii   rrrr      uu   uu   ssss
+      pp        aa   aa   pp   pp   ii   rr        uu   uu      ssss
+      pp          aaaaa   ppppp     ii   rr          uuuuu   sssss
+                          pp
+                          pp
+
+
+  Papirus icon theme for GTK
+  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+
+
+EOF
+
+echo "=> Removing Papirus icon theme for GTK ..."
+sudo rm -rf /usr/share/icons/Papirus-GTK /usr/share/icons/Papirus-Dark-GTK
+rm -rf ~/.icons/Papirus-GTK ~/.icons/Papirus-Dark-GTK
+echo "=> Done!"


### PR DESCRIPTION
This pull request contains new and some previous improvements to installation scripts, but left them simple.

Improvements:

* No dependencies. cURL and tar is preinstalled on many Linux systems
* New look and feel. You can test it using the fake installer
  ```curl -sL https://transfer.sh/lMcoa/fake-install-papirus-home.sh | sh```
* Removed bashism
* Deleted `chmod -R 755`. `cp --no-preserve=mode,ownership` — better way to fix permissions
* Added set -e to exit after any command failure #138 #140
* Not used wildcards #138 #140
* Removing previously installed theme only after downloading and extracting the new #138

Tested on: Ubuntu 14.04, Ubuntu 16.04, Fedora 24, Fedora 25, Manjaro 16.10 (Arch Linux), openSUSE 42

![screenshot from 2016-11-26 01-28-10](https://cloud.githubusercontent.com/assets/819186/20636685/29a4a9d6-b37a-11e6-943d-0f18d5d3b23b.png)