### PR TITLE
Fix installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,25 @@ Papirus - it's SVG icon theme for Linux, based on [Paper](https://github.com/snw
 # Install / Update
 ## ROOT directory
 ```
-curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-root.sh | sh
+wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-root.sh | sh
 ```
 ## HOME directory
 ```
-curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh
+wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh
 ```
 **Depends:**
-- curl
+- wget
 - tar
 - libqt4-svg (optional, need for right work on Qt4-apps)
 
 For easy way update you can add bash alias `update-papirus`:
 ```
-echo 'alias update-papirus="curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh"' >> ~/.bashrc
+echo 'alias update-papirus="wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/install-papirus-home.sh | sh"' >> ~/.bashrc
 ```
 
 # Remove
 ```
-curl -sL https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/remove-papirus.sh | sh
+wget -qO- https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/master/remove-papirus.sh | sh
 ```
 
 # Hardcoded tray icons

--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-cat <<- 'EOF'
+gh_repo="papirus-icon-theme-gtk"
+gh_desc="Papirus icon theme for GTK"
+
+cat <<- EOF
 
 
 
@@ -15,8 +18,8 @@ cat <<- 'EOF'
                           pp
 
 
-  Papirus icon theme for GTK
-  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+  $gh_desc
+  https://github.com/PapirusDevelopmentTeam/$gh_repo
 
 
 EOF
@@ -24,17 +27,17 @@ EOF
 temp_dir=$(mktemp -d)
 
 echo "=> Getting the latest version from GitHub ..."
-curl --progress-bar -Lfo /tmp/papirus-icon-theme-gtk.tar.gz \
-  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.tar.gz
+curl --progress-bar -Lfo "/tmp/$gh_repo.tar.gz" \
+  https://github.com/PapirusDevelopmentTeam/$gh_repo/archive/master.tar.gz
 echo "=> Unpacking archive ..."
-tar -xzf /tmp/papirus-icon-theme-gtk.tar.gz -C "$temp_dir"
-echo "=> Deleting old Papirus icon theme ..."
+tar -xzf "/tmp/$gh_repo.tar.gz" -C "$temp_dir"
+echo "=> Deleting old $gh_desc ..."
 rm -rf ~/.icons/Papirus-GTK ~/.icons/Papirus-Dark-GTK
 echo "=> Installing ..."
 mkdir -p ~/.icons
 cp --no-preserve=mode,ownership -r \
-  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-GTK" \
-  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-Dark-GTK" ~/.icons/
+  "$temp_dir/$gh_repo-master/Papirus-GTK" \
+  "$temp_dir/$gh_repo-master/Papirus-Dark-GTK" ~/.icons/
 echo "=> Clearing cache ..."
-rm -rf /tmp/papirus-icon-theme-gtk.tar.gz "$temp_dir"
+rm -rf "/tmp/$gh_repo.tar.gz" "$temp_dir"
 echo "=> Done!"

--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -38,6 +38,8 @@ mkdir -p ~/.icons
 cp --no-preserve=mode,ownership -r \
   "$temp_dir/$gh_repo-master/Papirus-GTK" \
   "$temp_dir/$gh_repo-master/Papirus-Dark-GTK" ~/.icons/
+gtk-update-icon-cache -q ~/.icons/Papirus-GTK || true
+gtk-update-icon-cache -q ~/.icons/Papirus-Dark-GTK || true
 echo "=> Clearing cache ..."
 rm -rf "/tmp/$gh_repo.tar.gz" "$temp_dir"
 echo "=> Done!"

--- a/install-papirus-home.sh
+++ b/install-papirus-home.sh
@@ -27,7 +27,7 @@ EOF
 temp_dir=$(mktemp -d)
 
 echo "=> Getting the latest version from GitHub ..."
-curl --progress-bar -Lfo "/tmp/$gh_repo.tar.gz" \
+wget -O "/tmp/$gh_repo.tar.gz" \
   https://github.com/PapirusDevelopmentTeam/$gh_repo/archive/master.tar.gz
 echo "=> Unpacking archive ..."
 tar -xzf "/tmp/$gh_repo.tar.gz" -C "$temp_dir"

--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -37,6 +37,8 @@ echo "=> Installing ..."
 sudo cp --no-preserve=mode,ownership -r \
   "$temp_dir/$gh_repo-master/Papirus-GTK" \
   "$temp_dir/$gh_repo-master/Papirus-Dark-GTK" /usr/share/icons/
+sudo gtk-update-icon-cache -q "/usr/share/icons/Papirus-GTK" || true
+sudo gtk-update-icon-cache -q "/usr/share/icons/Papirus-Dark-GTK" || true
 echo "=> Clearing cache ..."
 rm -rf "/tmp/$gh_repo.tar.gz" "$temp_dir"
 echo "=> Done!"

--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-cat <<- 'EOF'
+gh_repo="papirus-icon-theme-gtk"
+gh_desc="Papirus icon theme for GTK"
+
+cat <<- EOF
 
 
 
@@ -15,8 +18,8 @@ cat <<- 'EOF'
                           pp
 
 
-  Papirus icon theme for GTK
-  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+  $gh_desc
+  https://github.com/PapirusDevelopmentTeam/$gh_repo
 
 
 EOF
@@ -24,16 +27,16 @@ EOF
 temp_dir=$(mktemp -d)
 
 echo "=> Getting the latest version from GitHub ..."
-curl --progress-bar -Lfo /tmp/papirus-icon-theme-gtk.tar.gz \
-  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk/archive/master.tar.gz
+curl --progress-bar -Lfo "/tmp/$gh_repo.tar.gz" \
+  https://github.com/PapirusDevelopmentTeam/$gh_repo/archive/master.tar.gz
 echo "=> Unpacking archive ..."
-tar -xzf /tmp/papirus-icon-theme-gtk.tar.gz -C "$temp_dir"
-echo "=> Deleting old Papirus icon theme ..."
+tar -xzf "/tmp/$gh_repo.tar.gz" -C "$temp_dir"
+echo "=> Deleting old $gh_desc ..."
 sudo rm -rf /usr/share/icons/Papirus-GTK /usr/share/icons/Papirus-Dark-GTK
 echo "=> Installing ..."
 sudo cp --no-preserve=mode,ownership -r \
-  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-GTK" \
-  "$temp_dir/papirus-icon-theme-gtk-master/Papirus-Dark-GTK" /usr/share/icons/
+  "$temp_dir/$gh_repo-master/Papirus-GTK" \
+  "$temp_dir/$gh_repo-master/Papirus-Dark-GTK" /usr/share/icons/
 echo "=> Clearing cache ..."
-rm -rf /tmp/papirus-icon-theme-gtk.tar.gz "$temp_dir"
+rm -rf "/tmp/$gh_repo.tar.gz" "$temp_dir"
 echo "=> Done!"

--- a/install-papirus-root.sh
+++ b/install-papirus-root.sh
@@ -27,7 +27,7 @@ EOF
 temp_dir=$(mktemp -d)
 
 echo "=> Getting the latest version from GitHub ..."
-curl --progress-bar -Lfo "/tmp/$gh_repo.tar.gz" \
+wget -O "/tmp/$gh_repo.tar.gz" \
   https://github.com/PapirusDevelopmentTeam/$gh_repo/archive/master.tar.gz
 echo "=> Unpacking archive ..."
 tar -xzf "/tmp/$gh_repo.tar.gz" -C "$temp_dir"

--- a/remove-papirus.sh
+++ b/remove-papirus.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-cat <<- 'EOF'
+gh_repo="papirus-icon-theme-gtk"
+gh_desc="Papirus icon theme for GTK"
+
+cat <<- EOF
 
 
 
@@ -15,13 +18,13 @@ cat <<- 'EOF'
                           pp
 
 
-  Papirus icon theme for GTK
-  https://github.com/PapirusDevelopmentTeam/papirus-icon-theme-gtk
+  $gh_desc
+  https://github.com/PapirusDevelopmentTeam/$gh_repo
 
 
 EOF
 
-echo "=> Removing Papirus icon theme for GTK ..."
+echo "=> Removing $gh_desc ..."
 sudo rm -rf /usr/share/icons/Papirus-GTK /usr/share/icons/Papirus-Dark-GTK
 rm -rf ~/.icons/Papirus-GTK ~/.icons/Papirus-Dark-GTK
 echo "=> Done!"


### PR DESCRIPTION
PapirusDevelopmentTeam/papirus-icon-theme-gtk#160

* wget is back
* unified
* creates cache files for icon themes

from man gtk-update-icon-cache

> GTK+ can use the cache files created by gtk-update-icon-cache to **avoid a lot of system call and disk seek overhead** when the application starts.